### PR TITLE
Fix Bugs that Prevent Execution of Wrapper Scripts

### DIFF
--- a/code/step1_hintpolicy/wrapper_gen_all_hintpolicies_struct.py
+++ b/code/step1_hintpolicy/wrapper_gen_all_hintpolicies_struct.py
@@ -5,8 +5,8 @@ from code.step1_hintpolicy.wrapper_hintpolicies import get_sketch_hint as get_sk
 
 
 if __name__ == "__main__":
-    inputfolder = "../../data/input/"
-    outputfolder = "../../data/output/expert-survey-input-data/"
+    inputfolder = "./data/input/"
+    outputfolder = "./data/output/expert-survey-input-data/"
 
     task_ids = ['0', '3', '4', '5']
     student_ids = ['0', '1', '2', '3']

--- a/code/step1_hintpolicy/wrapper_hintpolicies.py
+++ b/code/step1_hintpolicy/wrapper_hintpolicies.py
@@ -5,7 +5,7 @@ from code.utils.sketch import json_to_sketch as json_to_sketch
 from code.utils.sketch import sketch_to_json as sketch_to_json
 from code.step1_hintpolicy.hintpolicy_struct_hop import get_sketch_one_hop as get_sketch_one_hop
 from code.step1_hintpolicy.hintpolicy_struct_multihop import get_sketch_multihop_2 as get_sketch_multihop_2
-from code.step1_hintpolicy.hintpolicy_struct_gcs import get_sketch_gcs as get_sketch_gcs
+# from code.step1_hintpolicy.hintpolicy_struct_gcs import get_sketch_gcs as get_sketch_gcs
 from code.step1_hintpolicy.hintpolicy_struct_same import get_sketch_same as get_sketch_same
 
 
@@ -20,7 +20,7 @@ alg_func_dict = {
     'reduced-code': 'get_sketch_multihop_2'
 }
 
-def gen_struct_images(structfile, outputfolder, inputfolder = '../../data/temp/'):
+def gen_struct_images(structfile, outputfolder, inputfolder = './data/input/temp_latex/'):
 
     struct_script = get_full_latex_script(structfile)
     with open(inputfolder + 'code_struct.tex', 'w') as fp:
@@ -28,9 +28,9 @@ def gen_struct_images(structfile, outputfolder, inputfolder = '../../data/temp/'
 
     # generate the image file
     input_path = inputfolder + 'code_struct.tex'
-    os.system("pdflatex -interaction=nonstopmode -output-directory ../../data/temp %s" % (input_path))
+    os.system("pdflatex -interaction=nonstopmode -output-directory ./data/input/temp_latex %s" % (input_path))
     output_path = outputfolder + 'code_struct.jpg'
-    os.system("convert -density 600 -quality 100 ../../data/temp/code_struct.pdf %s" % output_path)
+    os.system("convert -density 600 -quality 100 ./data/input/temp_latex/code_struct.pdf %s" % output_path)
 
     print("Generated sketch hint image")
     return
@@ -52,6 +52,7 @@ def get_sketch_hint(task_id, student_id, alg_id, inputfolder, outputfolder, save
         type = 'hoc'
 
     outputpath = outputfolder + 'task-' + task_id + '/student-' + student_id + '/alg-' + alg_id + '/'
+    os.makedirs(outputpath, exist_ok=True)
     sketch_hint = eval(alg_func_dict[alg_id])(stusketch, solsketch, type)
     sketch_hint_json = sketch_to_json(sketch_hint)
 

--- a/code/step4_intervention/wrapper_gen_intervention.py
+++ b/code/step4_intervention/wrapper_gen_intervention.py
@@ -20,10 +20,10 @@ This function ties all 3 parts together, and takes as input the task_id,  studen
 
 
 
-def full_run(task_ids:list, substructure_ids:list, bucket_sample_size = 3, sampling_size=50, verbose=False):
+def full_run(tid:tuple, substructure_ids:list, bucket_sample_size = 3, sampling_size=50, verbose=False):
 
     display_dict = {}
-    for tid in task_ids:
+    if True: # for tid in task_ids: Doing this to avoid massive code patches
         type = tid[1]
         sol_code_symast, sol_code_size = eval(config.INPUT_CODE_DICT[str(tid[0])])()
 
@@ -110,23 +110,23 @@ if __name__ == "__main__":
 
     # # run full_run
     task_ids_dict = {
-                "0": [0, 'hoc'],
-                "1": [1, 'hoc'],
-                "2": [2, 'hoc'],
-                "3": [3, 'hoc'],
-                "4": [4, 'karel'],
-                "5": [5, 'karel'],
-                "6": [6, 'karel'] # newly added Karel Task
+                "0": (0, 'hoc'),
+                "1": (1, 'hoc'),
+                "2": (2, 'hoc'),
+                "3": (3, 'hoc'),
+                "4": (4, 'karel'),
+                "5": (5, 'karel'),
+                "6": (6, 'karel') # newly added Karel Task
     }
 
-    task_ids = [task_ids_dict["0"], task_ids_dict["1"], task_ids_dict["2"], task_ids_dict["3"], task_ids_dict["4"], task_ids_dict["5"], task_ids_dict["6"]]
+    # task_ids = [task_ids_dict["0"], task_ids_dict["1"], task_ids_dict["2"], task_ids_dict["3"], task_ids_dict["4"], task_ids_dict["5"], task_ids_dict["6"]]
     substructure_ids_dict = {
                    "0": [0,1,2],
                    "1": [0,1,2],
                    "2": [0,1,2],
-                   "3": [0,1,2], # substructure ID 3 treated separately for additional code constraints.
+                   "3": [0,1,2,3], # substructure ID 3 treated separately for additional code constraints.
                    "4": [0,1,2],
-                   "5": [0,1], # substructure ID 2 treated separately for additional code constraints. Also runtime is higher than all others
+                   "5": [0,1,2], # substructure ID 2 treated separately for additional code constraints. Also runtime is higher than all others
                    "6": [0,1] # newly added Karel Task
 
                 }
@@ -137,7 +137,7 @@ if __name__ == "__main__":
         bucket_code_samples = 3
         sample_size = 2000
         #### generate all the task-code pairs
-        total_codes, display_dict = full_run(task_ids, sub_ids, bucket_sample_size=bucket_code_samples, sampling_size=sample_size, verbose=False)
+        total_codes, display_dict = full_run(task_ids_dict[key], sub_ids, bucket_sample_size=bucket_code_samples, sampling_size=sample_size, verbose=False)
         if total_codes is None:
             print("Unable to create all task-code pairs!")
             exit(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,13 @@
+boto==2.49.0
+networkx==2.6.3
+numpy==1.21.6
+pandas==1.3.5
+python-dateutil==2.8.2
+pytz==2023.2
+scipy==1.7.3
+six==1.16.0
+stanfordkarel==0.2.4
+tqdm==4.65.0
 z3==0.2.0
 z3-solver==4.8.11.0
 zss==1.2.0

--- a/run_demos_and_synthetics.sh
+++ b/run_demos_and_synthetics.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Runs the demos and synethics script executions for the repository in one command
+# Needs pdflatex (TeX Live) and convert (ImageMagick) to run in its entirety
+# Also uses Python >=3.7.3 for execution
+
+echo 'Running Demos...'
+
+python -m code.demo.run_fig1 --latex_images_flag 1
+python -m code.demo.run_fig5 --latex_images_flag 1
+
+echo 'Running Synthetics...'
+
+python -m code.step0_inputdata.wrapper_gen-all_input_data
+python -m code.step1_hintpolicy.wrapper_gen_all_hintpolicies_struct
+python -m code.step4_intervention.wrapper_gen_substructures
+python -m code.step4_intervention.wrapper_gen_intervention
+
+echo 'Finished! All outputs are in the \'.\/data\' folder'


### PR DESCRIPTION
This PR contains a number of bug fixes that would prevent the execution of the wrapper scripts in the repository. This does **not** fix all bugs throughout the codebase. Here are the bugs encountered in order and the resolution strategy.

### Not all python packages were provided

Not all the python packages needed to reproduce the code were provided for execution. They have been added to the `requirements.txt` file by attempting to load the wrapper scripts into a virtual environment and adding the necessary libraries to run the code.

### Cannot import `stanfordkarel`

In many of the wrapper scripts, they either explicitly mention or call out to `stanfordkarel` on generation. At first, I thought that the copied library was added as a local dependency; however, that still seemed to cause an issue as when running `run_random.run_random_with_quality_only`, the `val` outputted would always be `0` no matter what I did.

https://github.com/machine-teaching-group/aied2022_pquizsyn/blob/c7f772c2c9584d75d16249837f09fcfacfd816d5/code/step3_code2task/run_random.py#L116-L123

As such, I assumed there was still a local copy of `stanfordkarel` still on the machine when testing which obscured this error. As this didn't seem to effect the output of the code in any way, I simply added it as an additional dependency.

### Differing execution contexts

A lot of the scripts have differing execution contexts, expecting python to be executed in one directory or another. These have all been standardized to use the project directory instead as that is where the examples from the README are executed from.

### Generating hint policies from the `temp` input folder

`temp` does not exist as an input folder where it can pull the necessary `code_struct` information. As such, I changed the location to reflect the files that were generated in the previous step. It seems these were all directed to one file location anyway.

### Output directory doesn't exist

The output directory didn't exist when generating hint policies, so I made them generate manually.

### Incorrect looping of intervention execution

When the intervention logic was executed, it seemed to run an additional loop through the available tasks, causing all substructures to loop for every single available task, even if one wasn't present. The additional loop was removed and the substructures with additional constraints were added back in since they didn't seem to be affected.

## Bugs not fixed

### Output when generating some pdfs

Some pdfs during generation of the hint policies would return the following error:

```
! Undefined control sequence.
\textcode ...tfamily {cmtt}\selectfont #1}\xspace

l.130 \end{boxcode}
```

There was also some font related errors as well.

As it specifically only affected the pdfs and not the images itself, I did not resolve the issue as it would only affect the results if the experiment was replicated, to which the experiment would probably be changed by then.

### Cannot run results easily on Windows Native

The scripts cannot be run on Windows Native. This is simply due to the internal system calls to pdflatex (from texlive) and convert (from imagemagick). It can run on cygwin and mingw, however. So, a bash script has been provided as this is compatible across all systems. 

### No additional README information

I did not update the README as most of the errors that would be encounters are nonconsequential due to the reasons above. For future reference, you need gcc, g++, texlive, texlive-latex-extra, and imagemagick to run the codebase. Additionally, if you are running a later version of imagemagick which disables pdf conversion due to a bug in ghostscript prior to 9.24, check to make sure ghostscript is above 9.24 and then change /etc/ImageMagick-6/policy.xml to comment out the policy disabling pdf conversion.